### PR TITLE
Kismet nodes from text

### DIFF
--- a/docs/nodes_from_text.md
+++ b/docs/nodes_from_text.md
@@ -41,6 +41,8 @@ Then the template for a node would be:
 
 ```txt
 MyClass(myProp=0, secondProp="Hello world"):(<output_name>)
+// or when an input connection name is needed:
+MyClass(myProp=0, secondProp="Hello world"):(in=<input_name>, out=<output_name>)
 ```
 
 Note that the output name is not required if the only output name is `Out`:

--- a/docs/nodes_from_text.md
+++ b/docs/nodes_from_text.md
@@ -1,0 +1,109 @@
+# Kismet nodes from text
+
+## Input: node(s)
+
+Valid inputs are:
+
+- (friendly) class name of the kismet node
+- property chains (see example)
+- copied kismet node
+
+Example:
+
+```ts
+import { KismetFile } from 'kismet.code'
+
+const text = new KismetFile({ projectName: 'Untitled' }).textParser
+
+// Name of (friendly) class
+console.log(text.node('SeqAct_DrawText')?.toKismet())
+
+// Kismet node
+console.log(text.node(`
+Begin ...
+End
+`))
+
+// Chain of get properties
+const properties = 'Player().PRI.teamInfo.teamIndex' 
+// Also possible: PRI.teamInfo.teamIndex (assumes Player(allPlayers=True) as target object)
+console.log(text.node(properties)?.map(node => node.toKismet()))
+```
+
+## Input: sequence
+
+A sequence can be created from multiple nodes by connecting them with one of the following characters:
+
+- '>'
+- '->'
+
+Then the template for a node would be:
+
+```txt
+MyClass(myProp=0, secondProp="Hello world"):(<output_name>)
+```
+
+Note that the output name is not required if the only output name is `Out`:
+
+```ts
+AnotherClass(myProp=True) 
+// or:
+AnotherClass(myProp=True):()
+// or when no variables are used:
+AnotherClass():() 
+// Also valid:
+AnotherClass()
+AnotherClass
+```
+
+And when only an output name is needed, the following inputs are valid:
+
+```txt
+AnotherClass():(<output_name>)
+AnotherClass:(<output_name>)
+```
+
+Example:
+
+```ts
+import { KismetFile } from 'kismet.code'
+
+const text = new KismetFile({ projectName: 'Untitled' }).textParser
+
+const sequence = 'LevelLoaded:(visible) > CompareInt(0, 1):(A < B) > SeqAct_DrawText(String="hello world", Targets=Player(allPlayers=True))'
+
+console.log(text.sequence(sequence)?.toKismet())
+```
+
+### Subsequence
+
+To create a subsequence add `Sequence(mySequenceName):` before the sequence input
+
+## Unknown input
+
+When it is unknown whether the input is a sequence or node:
+
+```ts
+import { KismetFile } from 'kismet.code'
+
+const text = new KismetFile({ projectName: 'Untitled' }).textParser
+
+const input = 'your unknown input'
+
+if (text.isInvalidInput(input)) {
+    // no parsing is needed as the input is not valid
+}
+
+try {
+    if (text.isSequenceText(input)) {
+        // input is a sequence 
+        return text.sequence(input)
+    } else {
+        // input is a node
+        return text.node(input)
+    }
+} catch (err) {
+    // Handle errors 
+    console.error(err)
+}
+```

--- a/node/managers/ProcessManager.ts
+++ b/node/managers/ProcessManager.ts
@@ -22,11 +22,14 @@ export class ProcessId {
  */
 export const ProcessManager = new class ProcessManager {
     private ids: Map<string, number>
+    private overwrittenNumbers: Map<string, number[]>
+
     private logLevel: Constants.LogLevel
     private overwriteErrors: boolean
     
     constructor () {
         this.ids = new Map()
+        this.overwrittenNumbers = new Map()
 
         this.logLevel = Constants.LogLevel.ALL
         this.overwriteErrors = false
@@ -50,8 +53,17 @@ export const ProcessManager = new class ProcessManager {
      * Create a new id for a given class. 
      * The id can then be resolved into a name for linking nodes
      */
-    public id (Class: string): ProcessId {
+    public id (Class: string, number?: number): ProcessId {
         const count = this.ids.get(Class)
+
+        if (number != undefined) {
+            const numbers = this.overwrittenNumbers.get(Class)
+            if (!numbers?.some(n => n === number)) {
+                this.overwrittenNumbers.set(Class, (numbers ?? []).concat(number))
+            } else {
+                throw new Error('Cannot have multiple items of the same class with the same id')
+            }
+        } 
 
         this.ids.set(Class, count != undefined ? count + 1 : 0)
 

--- a/node/managers/ProcessManager.ts
+++ b/node/managers/ProcessManager.ts
@@ -1,3 +1,6 @@
+import { Constants } from "../shared/index.js"
+import { ProcessOptions } from "../types/options.js"
+
 export class ProcessId {
     private readonly id: string
 
@@ -14,11 +17,19 @@ export class ProcessId {
     }
 }
 
+/**
+ * Internal class used for handling connections and output 
+ */
 export const ProcessManager = new class ProcessManager {
     private ids: Map<string, number>
-
+    private logLevel: Constants.LogLevel
+    private overwriteErrors: boolean
+    
     constructor () {
         this.ids = new Map()
+
+        this.logLevel = Constants.LogLevel.ALL
+        this.overwriteErrors = false
     }
 
     private createId (id: string) {
@@ -27,11 +38,52 @@ export const ProcessManager = new class ProcessManager {
         return new ProcessId(buffer)
     }
 
+    private get throwError (): boolean {
+        if (this.overwriteErrors) {
+            return true
+        }
+
+        return this.logLevel <= Constants.LogLevel.ERRORS
+    }
+
+    /**
+     * Create a new id for a given class. 
+     * The id can then be resolved into a name for linking nodes
+     */
     public id (Class: string): ProcessId {
         const count = this.ids.get(Class)
 
         this.ids.set(Class, count != undefined ? count + 1 : 0)
 
         return this.createId(`${Class}|${count ?? 0}`)
+    }
+
+    /**
+     * Log output information  
+     * @param text The text to log
+     * @param channel The process channel: stdout or stderr
+     */
+    public log (text: string, channel: 'out' | 'error' = 'out'): void {
+        switch (channel) {
+            case 'out': 
+                if (this.logLevel <= Constants.LogLevel.DEBUG) process.stdout.write(text)
+                break
+            case 'error':
+                if (this.throwError) process.stderr.write(text)
+                break
+            default: 
+                if (this.throwError) {
+                    process.stderr.write('Unknown log channel: ' + channel)
+                }
+        }
+    }
+
+    /**
+     * Change the behaviour for handling errors and logging events
+     */
+    public setLogOptions (options: ProcessOptions): void {
+        this.logLevel = options.logLevel ?? Constants.LogLevel.ALL
+
+        this.overwriteErrors = options.throwOnError ?? false
     }
 }

--- a/node/managers/TextManager.ts
+++ b/node/managers/TextManager.ts
@@ -1,0 +1,86 @@
+import { Constants, t } from "../shared/index.js";
+import { SequenceItemType } from "../types/index.js";
+
+interface ItemInput extends Record<string, Record<string, unknown>> {
+    actions: Record<string, SequenceItemType>,
+    events: Record<string, SequenceItemType>,
+    conditions: Record<string, SequenceItemType>
+}
+
+export class TextManager {
+    public items: ItemInput;
+
+    public splitChars: string[];
+    public propertyChar: string;
+
+    private itemNames: [string, string][];
+
+    constructor (items: ItemInput) {
+        this.items = items
+
+        class A {
+            public linkId = ""
+        }
+
+        this.itemNames = Object.keys(items).map(n => Object.keys(items[n]).map(k => {
+            try{
+                return [new (items[n][k] as typeof A)().linkId.split('\'')[0], k]
+            } catch (err) {
+                //
+            }
+        })).flat().filter(n => n != undefined) as [string, string][]
+
+        this.splitChars = ['->', '>']
+        this.propertyChar = '.'
+    }
+
+    public findNodeName (input: string): string | undefined {
+        return this.itemNames.find(n => n.some(k => k.toLowerCase() === input.toLowerCase().trim()))?.[1]
+    }
+
+    public isNodeText (input: string): boolean {
+        return input.startsWith(Constants.KISMET_NODE_LINES.begin('', ''))
+    }
+
+    public isSequenceText (input: string): boolean {
+        return this.splitChars.some(n => input.includes(n))
+    }
+
+    public nodeFromText (input: string): null | undefined {
+        if (this.isNodeText(input)) {
+            console.log('Input is normal node')
+            const nodes = input.split('End Object').map(n => n.split('\n'))
+
+            for (const node of nodes) {
+                console.log(node)
+            }
+        } else return null
+    }
+ 
+    public SequenceFromText (input: string): void {
+        if (this.isSequenceText(input)) {
+            const splitChar = this.splitChars.find(n => input.includes(n)) as string
+
+            for (const node of input.split(splitChar)) {
+                if (!node.includes(this.propertyChar)) {
+                    const ClassName = this.findNodeName(node)
+
+                    if (ClassName) {
+                        console.log(ClassName)
+                    } else {
+                        throw new Error('Unable to process sequence: no class found for ' + node)
+                    }
+                } else {
+                    const [nodeName, ...props] = node.split(this.propertyChar)
+                    const ClassName = this.findNodeName(nodeName)
+
+                    if (ClassName) {
+                        console.log(ClassName, props)
+                    } else {
+                        throw new Error('Unable to process sequence: no class found for ' + nodeName)
+                    }
+                }
+            }
+        } else throw new Error ('Unable to process sequence: input contains no follow up')
+    }
+}

--- a/node/managers/TextManager.ts
+++ b/node/managers/TextManager.ts
@@ -1,52 +1,83 @@
-import { Constants, t } from "../shared/index.js";
-import { SequenceItemType } from "../types/index.js";
+import { Variables } from "../items/index.js";
 
-interface ItemInput extends Record<string, Record<string, unknown>> {
-    actions: Record<string, SequenceItemType>,
-    events: Record<string, SequenceItemType>,
-    conditions: Record<string, SequenceItemType>
+import { BaseSequenceItem, SequenceAction, SequenceVariable } from "../structures/index.js";
+
+import { 
+    Constants, 
+    t 
+} from "../shared/index.js";
+
+import type { 
+    Class,
+    SequenceItemType,
+    TextManagerInput
+} from "../types/index.js";
+
+import { actions } from "../test/index.js";
+
+const { GetProperty } = actions
+const { Player } = Variables
+
+class ItemType {
+    public linkId = ''
 }
 
-export class TextManager {
-    public items: ItemInput;
+export class TextManager<T extends TextManagerInput> {
+    public items: BaseSequenceItem[];
 
-    public splitChars: string[];
-    public propertyChar: string;
+    public splitChars = ['->', '>']
+    public propertyChar = '.'
+    public connectionChar = ':'
 
     private itemNames: [string, string][];
 
-    constructor (items: ItemInput) {
-        this.items = items
+    constructor (items: T) {
+        this.items = Object.keys(items)
+            .map(n => Object.keys(items[n])
+                .map(k => items[n][k])
+            ).flat() as BaseSequenceItem[]
 
-        class A {
-            public linkId = ""
-        }
+        this.itemNames = this.items.map(n => {
+            try {
+                const Class = t<typeof ItemType>(n)
 
-        this.itemNames = Object.keys(items).map(n => Object.keys(items[n]).map(k => {
-            try{
-                return [new (items[n][k] as typeof A)().linkId.split('\'')[0], k]
+                return [new Class().linkId.split('\'')[0], t<Function>(n).name]
             } catch (err) {
                 //
             }
-        })).flat().filter(n => n != undefined) as [string, string][]
-
-        this.splitChars = ['->', '>']
-        this.propertyChar = '.'
+        }).filter(n => n) as [string, string][]
     }
 
-    public findNodeName (input: string): string | undefined {
+    private findNodeName (input: string): string | undefined {
         return this.itemNames.find(n => n.some(k => k.toLowerCase() === input.toLowerCase().trim()))?.[1]
     }
 
-    public isNodeText (input: string): boolean {
+    private isNodeText (input: string): boolean {
         return input.startsWith(Constants.KISMET_NODE_LINES.begin('', ''))
     }
 
-    public isSequenceText (input: string): boolean {
+    private isSequenceText (input: string): boolean {
         return this.splitChars.some(n => input.includes(n))
     }
 
-    public nodeFromText (input: string): null | undefined {
+    private propertiesFromNodeInput (input: string) {
+        const parseProperty = (input: string) => input.includes('=') ? {
+            name: input.split('=')[0],
+            value: input.split('=')[1]
+        } : null
+
+        if (input.includes('(')) {
+            const properties = input.slice(input.indexOf('(') + 1, input.indexOf(')'))
+
+            if (properties.includes(',')) {
+                return properties.split(',').filter(n => n).map(n => parseProperty(n)).filter(n => n != null) as { name: string, value: string }[]
+            } else {
+                return [parseProperty(input)]
+            }
+        } else return null
+    }
+
+    public async nodeFromText (input: string): Promise<SequenceItemType | SequenceItemType[] | undefined> {
         if (this.isNodeText(input)) {
             console.log('Input is normal node')
             const nodes = input.split('End Object').map(n => n.split('\n'))
@@ -54,30 +85,96 @@ export class TextManager {
             for (const node of nodes) {
                 console.log(node)
             }
-        } else return null
+        } else if (this.findNodeName(input)) {
+
+            return await this.createNode(this.findNodeName(input) as string)
+        } else if (input.includes(this.propertyChar)) {
+
+            const [obj, ...properties] = input.toLowerCase().split(this.propertyChar)
+
+            if (!obj.includes('player(')) {
+                throw new Error('Property chains for objects other than the player class are not supported')
+            }
+
+            const playerOptions = this.propertiesFromNodeInput(obj)
+            
+            const allPlayers = Boolean(playerOptions?.find(n => n?.name === 'allplayers')?.value)
+            const index = Number(playerOptions?.find(n => n?.name === 'playeridx')?.value ?? 0)
+
+            const player = new Player()
+                .setAllPlayer(allPlayers)
+                .setPlayerIndex(index)
+
+            const output = []
+            let lastProperty: SequenceAction | null = null, lastVar: SequenceVariable | null = null
+
+            properties.forEach((n, i) => {
+                const node = new GetProperty();
+
+                const propertyName = n.includes('(') ? n.slice(0, n.indexOf('(')) : n
+                const type = n.includes('(') ? n.slice(n.indexOf('('), -1) : 'Object'
+
+                const variable = Object.keys(Variables).find(n => n === type)
+
+                const Var = variable ? new ((Variables as Record<string, unknown>)[variable] as Class<SequenceVariable>)() : new Variables.Object()
+
+                if (i === 0) {
+                    node.setVariable('Target', player)
+                        .setVariable('PropertyName', propertyName)
+                        .setVariable(type, Var.linkId)
+                } else {
+                    node.setVariable('Target', player)
+                        .setVariable('PropertyName', propertyName)
+                        .setVariable(type, (lastVar as SequenceVariable).linkId)
+
+                    lastProperty?.addConnection(node, 'Out', 'In')
+                }
+
+                lastProperty = node
+                lastVar = Var
+
+                output.push(node, Var)
+            })
+
+            output.push(player)
+
+            return output
+        } else return undefined
+    }
+
+    private createNode (inputName: string) {
+        const className = this.findNodeName(inputName)
+        if (!className) throw new Error('No class found with name: ' + inputName)
+
+        const Class = this.items.find(n => t<Function>(n).name === className)
+
+        const itemClass = t<typeof ItemType>(Class)
+        const item = new itemClass() as SequenceItemType
+
+        return item
     }
  
-    public SequenceFromText (input: string): void {
+    public sequenceFromText (input: string): void {
+        const output = []
+
         if (this.isSequenceText(input)) {
             const splitChar = this.splitChars.find(n => input.includes(n)) as string
 
             for (const node of input.split(splitChar)) {
                 if (!node.includes(this.propertyChar)) {
-                    const ClassName = this.findNodeName(node)
 
-                    if (ClassName) {
-                        console.log(ClassName)
-                    } else {
-                        throw new Error('Unable to process sequence: no class found for ' + node)
+                    const item = this.createNode(node)
+
+                    if (item) {
+                        console.log(item)
                     }
+                        
                 } else {
                     const [nodeName, ...props] = node.split(this.propertyChar)
-                    const ClassName = this.findNodeName(nodeName)
+                    const item = this.createNode(nodeName)
 
-                    if (ClassName) {
-                        console.log(ClassName, props)
-                    } else {
-                        throw new Error('Unable to process sequence: no class found for ' + nodeName)
+                    if (item) {
+                        console.log(item)
                     }
                 }
             }

--- a/node/shared/kismet.ts
+++ b/node/shared/kismet.ts
@@ -17,8 +17,53 @@ export function addVariable (node: string, variable: KismetVariableInternalTypeL
     }).join('\n')
 }
 
-export function boolToKismet (input: boolean | null): string {
+export function boolToKismet (input: boolean | string | null): string {
+    if (typeof input === 'string') {
+        const output = input === 'true' ? KismetBoolean.True : (
+            input === 'false' ? KismetBoolean.False : undefined
+        )
+
+        if (output != undefined) return output
+        else throw new Error('Unexpected boolean input: ' + input)
+    }
+
     return input ? KismetBoolean.True : KismetBoolean.False
+}
+
+export function arrayFromText (input: string): [string, string][] {
+    if (input[0] !== '(' || input.at(-1) !== ')') {
+        throw new Error('Invalid input array: ' + input)
+    }
+
+    const values = input.slice(1, -1)
+
+    if (values.includes('LinkedVariables') || values.includes('LinkedOp')) {
+        // Handle variable and input/output link arrays
+        return values.split(/(?<!LinkedOp)=/g).map((line, i, lines) => {
+            if ((i + 1) < lines.length) {
+                const index = line.lastIndexOf(',')
+                const name = index > 0 ? line.slice(index + 1) : line
+                    
+                const nextIndex = lines[i + 1].lastIndexOf(',')
+                const value = nextIndex > 0 ? lines[i + 1].slice(0, nextIndex) : lines[i + 1]
+
+                return [name, value]
+            } else return null
+        }).filter(n => n) as [string, string][]
+    } else {
+        return values.split(',').map(n => propertyFromText(n))
+    }
+}
+
+export function propertyFromText (rawInput: string): [string, string] {
+    const input = rawInput.trim()
+    
+    if (!input.includes('=')) {
+        throw new Error('Unexpected property input. Missing character \'=\' in line: ' + input)
+    }
+
+    const split = input.indexOf('=')
+    return [input.slice(0, split), input.slice(split + 1)]
 }
 
 export function parseVar (name: string, value: KismetVariablesType): string {

--- a/node/structures/project.ts
+++ b/node/structures/project.ts
@@ -10,9 +10,14 @@ import {
     Variables 
 } from '../items/index.js'
 
+import { 
+    ProcessManager 
+} from '../managers/index.js'
+
 import { CustomNodesManager } from './parser.js';
 
 import type { 
+    ProcessOptions,
     projectOptions
 } from '../types/index.js'
 
@@ -25,7 +30,7 @@ export class KismetFile {
         space: number; 
     };
 
-    constructor (options: projectOptions) {
+    constructor (options: projectOptions & ProcessOptions) {
         const { projectName } = options
 
         this.projectName = projectName
@@ -41,6 +46,8 @@ export class KismetFile {
         this.mainSequence = new Sequence('Main_Sequence')
 
         this.parser = new CustomNodesManager('./node/test/')
+
+        ProcessManager.setLogOptions(options)
     }
 
     static Items = {

--- a/node/types/enums.ts
+++ b/node/types/enums.ts
@@ -14,6 +14,13 @@ export enum KismetBoolean {
     False = 'False'
 }
 
+export enum LogLevel {
+    ALL = 0,
+    DEBUG = 1,
+    ERRORS = 2,
+    NOTHING = 3
+}
+
 export enum NodeProperty {
     CATEGORY = 'ObjCategory',
     LINKS_INPUT = 'InputLinks',

--- a/node/types/index.ts
+++ b/node/types/index.ts
@@ -9,10 +9,20 @@ export * from './connectionLink.js'
 export * from './options.js'
 export * from './parser.js'
 
+export interface Class<T> {
+    new (): T; 
+}
+
 export interface KismetVectorComponents {
     x: number,
     y: number,
     z: number
+}
+
+export interface TextManagerInput<T = unknown> extends Record<string, Record<string, unknown>> {
+    actions: Record<string, T>,
+    events: Record<string, T>,
+    conditions: Record<string, T>
 }
 
 export type UDKSceneObject = string

--- a/node/types/options.ts
+++ b/node/types/options.ts
@@ -3,6 +3,8 @@ import {
     SequenceCondition
 } from '../structures/Sequence/index.js'
 
+import { LogLevel } from './enums.js'
+
 export interface layoutOptions {
     startX?: number
     startY?: number
@@ -12,6 +14,11 @@ export interface layoutOptions {
 export interface projectOptions {
     projectName: string
     layout?: layoutOptions
+}
+
+export interface ProcessOptions {
+    logLevel?: LogLevel
+    throwOnError?: boolean
 }
 
 export interface TextManagerCharOptions { 

--- a/node/types/options.ts
+++ b/node/types/options.ts
@@ -40,6 +40,14 @@ export interface BaseKismetItemOptions {
         output?: string[],
         variable?: string[]
     }
+    textOptions?: {
+        overwriteNumber?: number
+        sequence?: string
+        position?: { 
+            x: number,
+            y: number
+        }
+    }
     Draw?: {
         width: number
         maxWidth?: number

--- a/node/types/options.ts
+++ b/node/types/options.ts
@@ -14,6 +14,12 @@ export interface projectOptions {
     layout?: layoutOptions
 }
 
+export interface TextManagerCharOptions { 
+    split?: string[]
+    property?: string
+    connection?: string 
+}
+
 export interface BaseKismetConnectionOptions {
     Draw: number,
     OverrideDelta: number


### PR DESCRIPTION
Allows text to be converted into kismet nodes (formatted) that can be copied into UDK

Examples:
```txt
Input: 
SeqAct_DrawText
levelLoaded

Output:
// Kismet node for Draw text action
// Kismet node for level loaded event
```
Getting properties can also be chained:
```txt
Input:
Player().PRI.TeamInfo.<int>TeamIndex

Output:
// Player variable
// get property PRI of Player
// get property TeamInfo of PRI
...etc
```

Sequences can also be an input
```txt
Input:
Levelloaded -> CompareInt -> SeqAct_DrawText
LevelLoaded:(visible) > CompareInt(0, 1):(A < B) > SeqAct_DrawText(String="hello world", Targets=Player(allPlayers=True))

LevelLoaded:(visible) 
    CompareInt(0, 1):(A < B) 
        SeqAct_DrawText(String="hello world", Targets=Player(allPlayers=True))
```
